### PR TITLE
Fix the bug that the app crashes if using together with ImagePicker

### DIFF
--- a/android/src/main/java/me/vanpan/rctqqsdk/QQSDK.java
+++ b/android/src/main/java/me/vanpan/rctqqsdk/QQSDK.java
@@ -76,23 +76,21 @@ public class QQSDK extends ReactContextBaseJavaModule {
 
         @Override
         public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
-            mTencent.onActivityResultData(requestCode,resultCode,intent,loginListener);
             if (requestCode == Constants.REQUEST_API) {
                 if (resultCode == Constants.REQUEST_LOGIN) {
-                    Tencent.handleResultData(intent, loginListener);
+                    mTencent.onActivityResultData(requestCode, resultCode, intent, loginListener);
                 }
             }
             if (requestCode == Constants.REQUEST_QQ_SHARE) {
                 if (resultCode == Constants.ACTIVITY_OK) {
-                    Tencent.handleResultData(intent, qqShareListener);
+                    mTencent.onActivityResultData(requestCode, resultCode, intent, qqShareListener);
                 }
             }
             if (requestCode == Constants.REQUEST_QZONE_SHARE) {
                 if (resultCode == Constants.ACTIVITY_OK) {
-                    Tencent.handleResultData(intent, qZoneShareListener);
+                    mTencent.onActivityResultData(requestCode, resultCode, intent, qZoneShareListener);
                 }
             }
-            super.onActivityResult(activity, requestCode, resultCode, intent);
         }
     };
 


### PR DESCRIPTION
当和其他React Native原生模块一起使用的时候，以[marcshilling/react-native-image-picker](https://github.com/marcshilling/react-native-image-picker)为例，ImagePicker也会调用`startActivityForResult(Intent, int, Bundle)`，继而触发QQSDK模块中的监听器。因此，需要先判断result是否来自本模块的调用。另外，`Tencent.onActivityResultData(int ,int , Intent, IUiListener)`和`Tencent.handleResultData(Intent, IUiListener)`在内部均会触发回调（事实上他们内部对回调的行为很相似），两个都调用会导致Promise被重复触发导致出错。根据坑爹的官方文档，使用`Tencent.onActivityResultData(int ,int , Intent, IUiListener)`就足够了。