### PR TITLE
修复无法分享大图的bug

### DIFF
--- a/ios/RCTQQSDK/RCTQQSDK.m
+++ b/ios/RCTQQSDK/RCTQQSDK.m
@@ -227,7 +227,7 @@ RCT_EXPORT_METHOD(shareVideo:(NSString *)previewUrl
             NSString *title = [shareData objectForKey:@"title"];
             NSString *description = [shareData objectForKey:@"description"];
             QQApiImageObject *imgObj = [QQApiImageObject objectWithData:data
-                                                       previewImageData:data
+                                                       previewImageData:nil
                                                                   title:title
                                                             description:description];
             imgObj.shareDestType = ShareDestTypeQQ;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-qqsdk",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "react-native wrapper for qq sdk",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
现在使用 `shareImage` 分享大图会报错

```
2017-05-15:09:37:53:829 -QQAPI- QQApiMessageAndUrlConverter.m:425 param error: preview image data is too big
2017-05-15:09:37:53:830 -QQAPI- QQApi.m:511 param error: illegal object param
```
`previewImageData`在分享图片的时候是一个无用的参数,但是如果图片过大会报错.